### PR TITLE
Feat/app attest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-native-ios11-devicecheck (RNIOS11DeviceCheck)
 
-React Native implementation for Apple iOS 11 DeviceCheck DCDevice API. Except iOS platform always comes on `Promise.reject('Other than iOS platform not supported')`
+React Native implementation for Apple iOS 11 DeviceCheck DCDevice API and Apple iOS 14 DeviceCheck DCAppAttestService API. Except iOS platform always comes on `Promise.reject('Other than iOS platform not supported')`
 
 ![](https://img.shields.io/badge/pod_RNIOS11DeviceCheck-v0.0.3-green.svg?style=flat)
 ![](https://img.shields.io/badge/npm_react--native--ios11--devicecheck-v0.0.3-green.svg?style=flat)
@@ -14,7 +14,7 @@ React Native implementation for Apple iOS 11 DeviceCheck DCDevice API. Except iO
 
 `$ npm i --save react-native-ios11-devicecheck`
 
-# Implemtation (iOS Only using cocoapods, no need to do anything on android):
+# DCDevice implementation (iOS Only using cocoapods, no need to do anything on android):
 
 `pod 'RNIOS11DeviceCheck', :path => '../node_modules/react-native-ios11-devicecheck/ios'`
 
@@ -30,6 +30,34 @@ export default class App extends React.Component {
 		RNIOS11DeviceCheck
 			.getToken()
 			.then(console.warn)
+			.catch(console.warn);
+	};
+
+	render = () => <View style={{ flex: 1, backgroundColor: 'white' />;
+}
+```
+
+# DCAppAttestService implementation (iOS Only using cocoapods, no need to do anything on android):
+
+`pod 'RNIOS11DeviceCheck', :path => '../node_modules/react-native-ios11-devicecheck/ios'`
+
+Try inside javascript code: `index.js`
+
+```javascript
+import React from 'react';
+import { View } from 'react-native';
+import RNIOS11DeviceCheck from 'react-native-ios11-devicecheck';
+
+export default class App extends React.Component {
+	componentDidMount = () => {
+		const challenge = 'ABDCEFGHIJKL' // retrieve a challenge from your app's backend server
+
+		RNIOS11DeviceCheck
+			.generateKey()
+			.then(keyId => {
+				return RNIOS11DeviceCheck.attestKey(keyId, challenge)
+			})
+			.then(console.warn) // send the attestationKey to your app's backend server
 			.catch(console.warn);
 	};
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,19 @@ const getToken = (): Promise => {
 	return Promise.reject('Other than iOS platform not supported');
 };
 
+const generateKey = (): Promise => {
+	if (Platform.OS === 'ios') {
+		return new Promise((resolve, reject) =>
+			bridge
+				.generateKey()
+				.then(resolve)
+				.catch(reject)
+		);
+	}
+	return Promise.reject('Other than iOS platform not supported');
+};
+
 module.exports = {
-	getToken
+	getToken,
+	generateKey
 };

--- a/index.js
+++ b/index.js
@@ -31,7 +31,20 @@ const generateKey = (): Promise => {
 	return Promise.reject('Other than iOS platform not supported');
 };
 
+const attestKey = (keyId, challenge): Promise => {
+	if (Platform.OS === 'ios') {
+		return new Promise((resolve, reject) =>
+			bridge
+				.attestKey(keyId, challenge)
+				.then(resolve)
+				.catch(reject)
+		);
+	}
+	return Promise.reject('Other than iOS platform not supported');
+};
+
 module.exports = {
 	getToken,
-	generateKey
+	generateKey,
+	attestKey
 };

--- a/ios/RNIOS11DeviceCheck.m
+++ b/ios/RNIOS11DeviceCheck.m
@@ -5,6 +5,7 @@
 
 #import "RNIOS11DeviceCheck.h"
 #import <DeviceCheck/DeviceCheck.h>
+#import <CommonCrypto/CommonDigest.h>
 
 typedef void (^FailureHandleErrorBlock)(NSError* error, NSString *errorType);
 
@@ -68,6 +69,47 @@ RCT_EXPORT_METHOD(generateKey:(RCTPromiseResolveBlock)resolve
                     failureBlock(error, @"cannot-create");
                 } else {
                     failureBlock(nil, @"unknown-trouble-to-generate-key");
+                }
+            }];
+        } else {
+            failureBlock(nil, @"device-not-supported");
+        }
+    } else {
+        failureBlock(nil, nil);
+    }
+}
+
+RCT_EXPORT_METHOD(attestKey:(NSString *)keyId
+                  challenge:(NSString *)challenge
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    FailureHandleErrorBlock failureBlock = ^void(NSError* error, NSString *errorType) {
+        NSString *errorDomain = [NSString stringWithFormat:@"com.apple.devicecheck.error.%@", errorType ?: @"ios-version-not-supported"];
+        if (!error) {
+            error = [[NSError alloc] initWithDomain:errorDomain
+                code:400
+                userInfo:@{NSLocalizedDescriptionKey: @"This device does not support Apple AppAttest API, due to below iOS 14 version or simulator."}
+            ];
+        }
+        reject(errorDomain, error.localizedDescription, error);
+    };
+    
+    if (@available(iOS 14.0, *)) {
+        if (DCAppAttestService.sharedService.isSupported) {
+            NSData* data = [challenge dataUsingEncoding:NSUTF8StringEncoding];
+            NSMutableData *sha256Data = [NSMutableData dataWithLength:CC_SHA256_DIGEST_LENGTH];
+            CC_SHA256([data bytes], (CC_LONG)[data length], [sha256Data mutableBytes]);
+            NSData * clientDataHash = [NSData dataWithData:sha256Data];
+
+            [DCAppAttestService.sharedService attestKey:keyId clientDataHash:clientDataHash completionHandler:^(NSData * _Nullable attestationObject, NSError * _Nullable error) {
+                if (!error && attestationObject) {
+                    NSData *data64 = [attestationObject base64EncodedDataWithOptions:NSDataBase64Encoding64CharacterLineLength];
+                    NSString *attestation64 = [[NSString alloc] initWithData:data64 encoding:NSUTF8StringEncoding];
+                    resolve(attestation64);
+                } else if (error) {
+                    failureBlock(error, @"cannot-attest");
+                } else {
+                    failureBlock(nil, @"unknown-trouble-to-attest-key");
                 }
             }];
         } else {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "react-native-ios11-devicecheck",
 	"version": "0.0.3",
 	"author": "Gaurav D. Sharma <er.gauravds@gmail.com>",
-	"description": "React Native implementation for Apple iOS 11 DeviceCheck DCDevice API.",
+	"description": "React Native implementation for Apple iOS 11 DeviceCheck DCDevice API and Apple iOS 14 DeviceCheck DCAppAttestService API.",
 	"homepage": "https://github.com/dayitv89/react-native-ios11-devicecheck.git",
 	"main": "index.js",
 	"repository": {


### PR DESCRIPTION
Hi,

I would like to add support for latest AppAttest API as described here : https://developer.apple.com/documentation/devicecheck/establishing_your_app_s_integrity

Your package seems to be a good place to implement this API as it is part of the DeviceCheck library, but if you prefer I can instead create a new package for this.

I implemented `generateKey` and `attestKey` entry points. But I did not implement `generateAssertion` as I did not use it yet and so I would not be able to test its implementation.

I have no experience in Objective-C so my implementation may be clunky although I tried to fit to the existing code, so you may want to double-check what I have done.

:warning: this API require iOS 14 or later, so this implementation may conflict with your package's name as it mention iOS 11.